### PR TITLE
Token refresh bug

### DIFF
--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -5,52 +5,6 @@ var aadOauth = (function () {
   let authResult = null;
   let redirectHandlerTask = null;
 
-  /** Set true in DevTools: window.__AAD_OAUTH_MSAL_DIAG_VERBOSE = true */
-  function diagVerbose() {
-    return typeof window !== 'undefined' && window.__AAD_OAUTH_MSAL_DIAG_VERBOSE === true;
-  }
-
-  function diag(phase, detail) {
-    const stamp = new Date().toISOString();
-    if (detail === undefined) {
-      console.log('[aad_oauth/msalv2]', stamp, phase);
-    } else if (diagVerbose()) {
-      console.log('[aad_oauth/msalv2]', stamp, phase, detail);
-    } else {
-      try {
-        const safe =
-          typeof detail === 'object' && detail !== null
-            ? JSON.stringify(detail)
-            : String(detail);
-        console.log('[aad_oauth/msalv2]', stamp, phase, safe);
-      } catch (_) {
-        console.log('[aad_oauth/msalv2]', stamp, phase, '(unserializable detail)');
-      }
-    }
-  }
-
-  function summarizeAuthResult(result) {
-    if (result == null) return { result: 'null' };
-    return {
-      hasAccessToken: !!(result.accessToken),
-      accessTokenLength: result.accessToken ? result.accessToken.length : 0,
-      hasAccount: !!(result.account),
-      accountUsername: result.account ? result.account.username : null,
-    };
-  }
-
-  function summarizeMsalError(err) {
-    if (err == null) return 'null';
-    return {
-      message: err.message || String(err),
-      name: err.name,
-      errorCode: err.errorCode,
-      errorMessage: err.errorMessage,
-      subError: err.suberror || err.subError,
-      stack: diagVerbose() && err.stack ? err.stack : undefined,
-    };
-  }
-
   const tokenRequest = {
     scopes: null,
     prompt: null,
@@ -76,17 +30,6 @@ var aadOauth = (function () {
 
   // Initialise the myMSALObj for the given client, authority and scope
   function init(config) {
-    diag('init:start', {
-      clientId: config.clientId,
-      tenant: config.tenant,
-      isB2C: !!config.isB2C,
-      redirectUri: config.redirectUri,
-      cacheLocation: config.cacheLocation,
-      scopeType: typeof config.scope,
-      scopeCount: typeof config.scope === 'string'
-        ? config.scope.split(' ').length
-        : (config.scope && config.scope.length) || 0,
-    });
     let authority;
     if (config.customAuthorizationUrl) {
       authority = deriveAuthorityFromAuthorizationUrl(config.customAuthorizationUrl);
@@ -138,18 +81,6 @@ var aadOauth = (function () {
     // can await its completion in the login API
 
     redirectHandlerTask = myMSALObj.handleRedirectPromise();
-    diag('init:handleRedirectPromise scheduled', { authority: authority });
-    redirectHandlerTask
-      .then(function (r) {
-        diag('init:handleRedirectPromise settled', {
-          hasResult: r != null,
-          summary: summarizeAuthResult(r),
-        });
-      })
-      .catch(function (e) {
-        diag('init:handleRedirectPromise rejected', summarizeMsalError(e));
-      });
-    diag('init:done');
   }
 
   // Tries to silently acquire a token. Will return null if a token
@@ -157,41 +88,24 @@ var aadOauth = (function () {
   // Will return the authentication result on success and update the
   // global authResult variable.
   async function silentlyAcquireToken() {
-    diag('silentlyAcquireToken:start', {
-      hasMyMSALObj: myMSALObj != null,
-      hasCachedAuthResult: authResult != null,
-    });
     try {
       // The redirect handler task will complete with auth results if we
       // were redirected from AAD. If not, it will complete with null
       // We must wait for it to complete before we allow the login to
       // attempt to acquire a token silently, and then progress to interactive
       // login (if silent acquisition fails).
-      diag('silentlyAcquireToken:await redirectHandlerTask…');
       let result = await redirectHandlerTask;
-      diag('silentlyAcquireToken:redirectHandlerTask resolved', {
-        hasResult: result != null,
-        summary: summarizeAuthResult(result),
-      });
       if (result !== null) {
         authResult = result;
-        diag('silentlyAcquireToken:return after redirect result', summarizeAuthResult(authResult));
         return authResult;
       }
     }
     catch (error) {
-      diag('silentlyAcquireToken:redirectHandlerTask catch (swallowed in original code)', summarizeMsalError(error));
       authResultError = null;
     }
 
     const account = getAccount();
-    diag('silentlyAcquireToken:after redirect branch', {
-      hasAccount: account != null,
-      accountUsername: account ? account.username : null,
-      homeAccountId: account ? account.homeAccountId : null,
-    });
     if (account == null) {
-      diag('silentlyAcquireToken:exit no account');
       return null;
     }
 
@@ -200,10 +114,6 @@ var aadOauth = (function () {
       // within its lifetime, or the refresh token can successfully be
       // used to refresh it. This will throw if the access token can't
       // be acquired.
-      diag('silentlyAcquireToken:acquireTokenSilent start', {
-        scopes: tokenRequest.scopes,
-        prompt: 'none',
-      });
       const silentAuthResult = await myMSALObj.acquireTokenSilent({
         scopes: tokenRequest.scopes,
         prompt: "none",
@@ -212,11 +122,9 @@ var aadOauth = (function () {
       });
 
       authResult = silentAuthResult;
-      diag('silentlyAcquireToken:acquireTokenSilent success', summarizeAuthResult(authResult));
       return authResult;
     } catch (error) {
       console.log('Unable to silently acquire a new token: ' + error.message);
-      diag('silentlyAcquireToken:acquireTokenSilent failed', summarizeMsalError(error));
       return null;
     }
 
@@ -240,26 +148,19 @@ var aadOauth = (function () {
   /// to attempt to refresh the token using an interactive login.
 
   async function login(refreshIfAvailable, useRedirect, onSuccess, onError) {
-    diag('login:start', { refreshIfAvailable: refreshIfAvailable, useRedirect: useRedirect });
     // Try to sign in silently, assuming we have already signed in and have
     // a cached access token
     await silentlyAcquireToken()
 
-    if(authResult != null) {
-      diag('login:onSuccess silent path', summarizeAuthResult(authResult));
+    if (authResult != null) {
       // Skip interactive login
       onSuccess(authResult.accessToken ?? null);
       return
     }
 
     const account = getAccount()
-    diag('login:after silent, no authResult', {
-      hasAccount: account != null,
-      useRedirect: useRedirect,
-    });
 
     if (useRedirect) {
-      diag('login:acquireTokenRedirect (navigation expected)');
       myMSALObj.acquireTokenRedirect({
         scopes: tokenRequest.scopes,
         prompt: tokenRequest.prompt,
@@ -268,7 +169,6 @@ var aadOauth = (function () {
         loginHint: tokenRequest.loginHint
       });
     } else {
-      diag('login:loginPopup start');
       // Sign in with popup
       try {
         const interactiveAuthResult = await myMSALObj.loginPopup({
@@ -281,11 +181,9 @@ var aadOauth = (function () {
 
         authResult = interactiveAuthResult;
 
-        diag('login:loginPopup success', summarizeAuthResult(authResult));
         onSuccess(authResult.accessToken ?? null);
       } catch (error) {
         // rethrow
-        diag('login:loginPopup error', summarizeMsalError(error));
         console.warn(error.message);
         onError(error);
       }
@@ -296,25 +194,18 @@ var aadOauth = (function () {
   // could not be acquired or if no cached account credentials exist.
   // Will call [onSuccess] on success and update the global authResult variable.
   async function refreshToken(onSuccess, onError) {
-    diag('refreshToken:start', { hasAuthResult: authResult != null });
     try {
       // The redirect handler task will complete with auth results if we
       // were redirected from AAD. If not, it will complete with null
       // We must wait for it to complete before we allow the login to
       // attempt to acquire a token silently, and then progress to interactive
       // login (if silent acquisition fails).
-      diag('refreshToken:await redirectHandlerTask…');
       let result = await redirectHandlerTask;
-      diag('refreshToken:redirectHandlerTask resolved', {
-        hasResult: result != null,
-        summary: summarizeAuthResult(result),
-      });
       if (result !== null) {
         authResult = result;
       }
     }
     catch (error) {
-      diag('refreshToken:redirectHandlerTask error → onError', summarizeMsalError(error));
       authResultError = error;
       onError(authResultError);
       return;
@@ -324,12 +215,10 @@ var aadOauth = (function () {
     // a cached access token
     await silentlyAcquireToken()
 
-    if(authResult != null) {
-      diag('refreshToken:onSuccess', summarizeAuthResult(authResult));
+    if (authResult != null) {
       onSuccess(authResult.accessToken ?? null);
       return
     }
-    diag('refreshToken:no token after silent → onError (Dart bridge)');
     onError(new Error('Silent token refresh did not produce a token'));
   }
 
@@ -338,43 +227,27 @@ var aadOauth = (function () {
     // otherwise we fallback to using MSAL APIs to find cached auth
     // accounts in browser storage.
     if (authResult !== null && authResult.account !== null) {
-      if (diagVerbose()) {
-        diag('getAccount:from authResult', {
-          username: authResult.account.username,
-          homeAccountId: authResult.account.homeAccountId,
-        });
-      }
       return authResult.account
     }
 
     const currentAccounts = myMSALObj.getAllAccounts();
 
     if (currentAccounts === null || currentAccounts.length === 0) {
-      diag('getAccount:no cached accounts in MSAL');
       return null;
     } else if (currentAccounts.length > 1) {
       // Multiple users - pick the first one, but this shouldn't happen
       console.warn("Multiple accounts detected, selecting first.");
-      diag('getAccount:multiple accounts, using first', { count: currentAccounts.length });
 
       return currentAccounts[0];
     } else if (currentAccounts.length === 1) {
-      if (diagVerbose()) {
-        diag('getAccount:single cached account', {
-          username: currentAccounts[0].username,
-          homeAccountId: currentAccounts[0].homeAccountId,
-        });
-      }
       return currentAccounts[0];
     }
   }
 
   function logout(onSuccess, onError, showPopup) {
-    diag('logout:start', { showPopup: showPopup });
     const account = getAccount();
 
     if (!account) {
-      diag('logout:no account, onSuccess immediately');
       onSuccess();
       return;
     }
@@ -384,13 +257,11 @@ var aadOauth = (function () {
     tokenRequest.scopes = null;
 
     if (showPopup) {
-      diag('logout:popup flow');
       myMSALObj
         .logout({ account: account })
         .then((_) => onSuccess())
         .catch(onError);
     } else {
-      diag('logout:logoutRedirect flow');
       myMSALObj
         .logoutRedirect({
           account: account,
@@ -406,31 +277,17 @@ var aadOauth = (function () {
   }
 
   async function getAccessToken() {
-    diag('getAccessToken:start');
     var result = await silentlyAcquireToken()
-    diag('getAccessToken:done', {
-      hasResult: result != null,
-      accessTokenLength: result && result.accessToken ? result.accessToken.length : 0,
-    });
     return result ? result.accessToken : null;
   }
 
   async function getIdToken() {
-    diag('getIdToken:start');
     var result = await silentlyAcquireToken()
-    diag('getIdToken:done', {
-      hasResult: result != null,
-      hasIdToken: !!(result && result.idToken),
-    });
     return result ? result.idToken : null;
   }
 
   function hasCachedAccountInformation() {
-    const has = getAccount() != null;
-    if (diagVerbose()) {
-      diag('hasCachedAccountInformation', { has: has });
-    }
-    return has;
+    return getAccount() != null;
   }
 
   return {

--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -218,6 +218,7 @@ var aadOauth = (function () {
       onSuccess(authResult.accessToken ?? null);
       return
     }
+    onError(new Error('Silent token refresh did not produce a token'));
   }
 
   function getAccount() {

--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -5,6 +5,52 @@ var aadOauth = (function () {
   let authResult = null;
   let redirectHandlerTask = null;
 
+  /** Set true in DevTools: window.__AAD_OAUTH_MSAL_DIAG_VERBOSE = true */
+  function diagVerbose() {
+    return typeof window !== 'undefined' && window.__AAD_OAUTH_MSAL_DIAG_VERBOSE === true;
+  }
+
+  function diag(phase, detail) {
+    const stamp = new Date().toISOString();
+    if (detail === undefined) {
+      console.log('[aad_oauth/msalv2]', stamp, phase);
+    } else if (diagVerbose()) {
+      console.log('[aad_oauth/msalv2]', stamp, phase, detail);
+    } else {
+      try {
+        const safe =
+          typeof detail === 'object' && detail !== null
+            ? JSON.stringify(detail)
+            : String(detail);
+        console.log('[aad_oauth/msalv2]', stamp, phase, safe);
+      } catch (_) {
+        console.log('[aad_oauth/msalv2]', stamp, phase, '(unserializable detail)');
+      }
+    }
+  }
+
+  function summarizeAuthResult(result) {
+    if (result == null) return { result: 'null' };
+    return {
+      hasAccessToken: !!(result.accessToken),
+      accessTokenLength: result.accessToken ? result.accessToken.length : 0,
+      hasAccount: !!(result.account),
+      accountUsername: result.account ? result.account.username : null,
+    };
+  }
+
+  function summarizeMsalError(err) {
+    if (err == null) return 'null';
+    return {
+      message: err.message || String(err),
+      name: err.name,
+      errorCode: err.errorCode,
+      errorMessage: err.errorMessage,
+      subError: err.suberror || err.subError,
+      stack: diagVerbose() && err.stack ? err.stack : undefined,
+    };
+  }
+
   const tokenRequest = {
     scopes: null,
     prompt: null,
@@ -30,6 +76,17 @@ var aadOauth = (function () {
 
   // Initialise the myMSALObj for the given client, authority and scope
   function init(config) {
+    diag('init:start', {
+      clientId: config.clientId,
+      tenant: config.tenant,
+      isB2C: !!config.isB2C,
+      redirectUri: config.redirectUri,
+      cacheLocation: config.cacheLocation,
+      scopeType: typeof config.scope,
+      scopeCount: typeof config.scope === 'string'
+        ? config.scope.split(' ').length
+        : (config.scope && config.scope.length) || 0,
+    });
     let authority;
     if (config.customAuthorizationUrl) {
       authority = deriveAuthorityFromAuthorizationUrl(config.customAuthorizationUrl);
@@ -81,6 +138,18 @@ var aadOauth = (function () {
     // can await its completion in the login API
 
     redirectHandlerTask = myMSALObj.handleRedirectPromise();
+    diag('init:handleRedirectPromise scheduled', { authority: authority });
+    redirectHandlerTask
+      .then(function (r) {
+        diag('init:handleRedirectPromise settled', {
+          hasResult: r != null,
+          summary: summarizeAuthResult(r),
+        });
+      })
+      .catch(function (e) {
+        diag('init:handleRedirectPromise rejected', summarizeMsalError(e));
+      });
+    diag('init:done');
   }
 
   // Tries to silently acquire a token. Will return null if a token
@@ -88,24 +157,41 @@ var aadOauth = (function () {
   // Will return the authentication result on success and update the
   // global authResult variable.
   async function silentlyAcquireToken() {
+    diag('silentlyAcquireToken:start', {
+      hasMyMSALObj: myMSALObj != null,
+      hasCachedAuthResult: authResult != null,
+    });
     try {
       // The redirect handler task will complete with auth results if we
       // were redirected from AAD. If not, it will complete with null
       // We must wait for it to complete before we allow the login to
       // attempt to acquire a token silently, and then progress to interactive
       // login (if silent acquisition fails).
+      diag('silentlyAcquireToken:await redirectHandlerTask…');
       let result = await redirectHandlerTask;
+      diag('silentlyAcquireToken:redirectHandlerTask resolved', {
+        hasResult: result != null,
+        summary: summarizeAuthResult(result),
+      });
       if (result !== null) {
         authResult = result;
+        diag('silentlyAcquireToken:return after redirect result', summarizeAuthResult(authResult));
         return authResult;
       }
     }
     catch (error) {
+      diag('silentlyAcquireToken:redirectHandlerTask catch (swallowed in original code)', summarizeMsalError(error));
       authResultError = null;
     }
 
     const account = getAccount();
+    diag('silentlyAcquireToken:after redirect branch', {
+      hasAccount: account != null,
+      accountUsername: account ? account.username : null,
+      homeAccountId: account ? account.homeAccountId : null,
+    });
     if (account == null) {
+      diag('silentlyAcquireToken:exit no account');
       return null;
     }
 
@@ -114,6 +200,10 @@ var aadOauth = (function () {
       // within its lifetime, or the refresh token can successfully be
       // used to refresh it. This will throw if the access token can't
       // be acquired.
+      diag('silentlyAcquireToken:acquireTokenSilent start', {
+        scopes: tokenRequest.scopes,
+        prompt: 'none',
+      });
       const silentAuthResult = await myMSALObj.acquireTokenSilent({
         scopes: tokenRequest.scopes,
         prompt: "none",
@@ -121,9 +211,12 @@ var aadOauth = (function () {
         extraQueryParameters: tokenRequest.extraQueryParameters
       });
 
-      return  authResult = silentAuthResult;
+      authResult = silentAuthResult;
+      diag('silentlyAcquireToken:acquireTokenSilent success', summarizeAuthResult(authResult));
+      return authResult;
     } catch (error) {
-      console.log('Unable to silently acquire a new token: ' + error.message)
+      console.log('Unable to silently acquire a new token: ' + error.message);
+      diag('silentlyAcquireToken:acquireTokenSilent failed', summarizeMsalError(error));
       return null;
     }
 
@@ -147,19 +240,26 @@ var aadOauth = (function () {
   /// to attempt to refresh the token using an interactive login.
 
   async function login(refreshIfAvailable, useRedirect, onSuccess, onError) {
+    diag('login:start', { refreshIfAvailable: refreshIfAvailable, useRedirect: useRedirect });
     // Try to sign in silently, assuming we have already signed in and have
     // a cached access token
     await silentlyAcquireToken()
 
     if(authResult != null) {
+      diag('login:onSuccess silent path', summarizeAuthResult(authResult));
       // Skip interactive login
       onSuccess(authResult.accessToken ?? null);
       return
     }
 
     const account = getAccount()
+    diag('login:after silent, no authResult', {
+      hasAccount: account != null,
+      useRedirect: useRedirect,
+    });
 
     if (useRedirect) {
+      diag('login:acquireTokenRedirect (navigation expected)');
       myMSALObj.acquireTokenRedirect({
         scopes: tokenRequest.scopes,
         prompt: tokenRequest.prompt,
@@ -168,6 +268,7 @@ var aadOauth = (function () {
         loginHint: tokenRequest.loginHint
       });
     } else {
+      diag('login:loginPopup start');
       // Sign in with popup
       try {
         const interactiveAuthResult = await myMSALObj.loginPopup({
@@ -180,9 +281,11 @@ var aadOauth = (function () {
 
         authResult = interactiveAuthResult;
 
+        diag('login:loginPopup success', summarizeAuthResult(authResult));
         onSuccess(authResult.accessToken ?? null);
       } catch (error) {
         // rethrow
+        diag('login:loginPopup error', summarizeMsalError(error));
         console.warn(error.message);
         onError(error);
       }
@@ -193,18 +296,25 @@ var aadOauth = (function () {
   // could not be acquired or if no cached account credentials exist.
   // Will call [onSuccess] on success and update the global authResult variable.
   async function refreshToken(onSuccess, onError) {
+    diag('refreshToken:start', { hasAuthResult: authResult != null });
     try {
       // The redirect handler task will complete with auth results if we
       // were redirected from AAD. If not, it will complete with null
       // We must wait for it to complete before we allow the login to
       // attempt to acquire a token silently, and then progress to interactive
       // login (if silent acquisition fails).
+      diag('refreshToken:await redirectHandlerTask…');
       let result = await redirectHandlerTask;
+      diag('refreshToken:redirectHandlerTask resolved', {
+        hasResult: result != null,
+        summary: summarizeAuthResult(result),
+      });
       if (result !== null) {
         authResult = result;
       }
     }
     catch (error) {
+      diag('refreshToken:redirectHandlerTask error → onError', summarizeMsalError(error));
       authResultError = error;
       onError(authResultError);
       return;
@@ -215,9 +325,11 @@ var aadOauth = (function () {
     await silentlyAcquireToken()
 
     if(authResult != null) {
+      diag('refreshToken:onSuccess', summarizeAuthResult(authResult));
       onSuccess(authResult.accessToken ?? null);
       return
     }
+    diag('refreshToken:no token after silent → onError (Dart bridge)');
     onError(new Error('Silent token refresh did not produce a token'));
   }
 
@@ -226,27 +338,43 @@ var aadOauth = (function () {
     // otherwise we fallback to using MSAL APIs to find cached auth
     // accounts in browser storage.
     if (authResult !== null && authResult.account !== null) {
+      if (diagVerbose()) {
+        diag('getAccount:from authResult', {
+          username: authResult.account.username,
+          homeAccountId: authResult.account.homeAccountId,
+        });
+      }
       return authResult.account
     }
 
     const currentAccounts = myMSALObj.getAllAccounts();
 
     if (currentAccounts === null || currentAccounts.length === 0) {
+      diag('getAccount:no cached accounts in MSAL');
       return null;
     } else if (currentAccounts.length > 1) {
       // Multiple users - pick the first one, but this shouldn't happen
       console.warn("Multiple accounts detected, selecting first.");
+      diag('getAccount:multiple accounts, using first', { count: currentAccounts.length });
 
       return currentAccounts[0];
     } else if (currentAccounts.length === 1) {
+      if (diagVerbose()) {
+        diag('getAccount:single cached account', {
+          username: currentAccounts[0].username,
+          homeAccountId: currentAccounts[0].homeAccountId,
+        });
+      }
       return currentAccounts[0];
     }
   }
 
   function logout(onSuccess, onError, showPopup) {
+    diag('logout:start', { showPopup: showPopup });
     const account = getAccount();
 
     if (!account) {
+      diag('logout:no account, onSuccess immediately');
       onSuccess();
       return;
     }
@@ -256,11 +384,13 @@ var aadOauth = (function () {
     tokenRequest.scopes = null;
 
     if (showPopup) {
+      diag('logout:popup flow');
       myMSALObj
         .logout({ account: account })
         .then((_) => onSuccess())
         .catch(onError);
     } else {
+      diag('logout:logoutRedirect flow');
       myMSALObj
         .logoutRedirect({
           account: account,
@@ -276,17 +406,31 @@ var aadOauth = (function () {
   }
 
   async function getAccessToken() {
+    diag('getAccessToken:start');
     var result = await silentlyAcquireToken()
+    diag('getAccessToken:done', {
+      hasResult: result != null,
+      accessTokenLength: result && result.accessToken ? result.accessToken.length : 0,
+    });
     return result ? result.accessToken : null;
   }
 
   async function getIdToken() {
+    diag('getIdToken:start');
     var result = await silentlyAcquireToken()
+    diag('getIdToken:done', {
+      hasResult: result != null,
+      hasIdToken: !!(result && result.idToken),
+    });
     return result ? result.idToken : null;
   }
 
   function hasCachedAccountInformation() {
-    return getAccount() != null;
+    const has = getAccount() != null;
+    if (diagVerbose()) {
+      diag('hasCachedAccountInformation', { has: has });
+    }
+    return has;
   }
 
   return {


### PR DESCRIPTION
fixes an error where a failure in the token refresh flow would cause the authentication to get stuck and never resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts MSAL token refresh/control-flow so failures now deterministically call `onError` instead of leaving callers waiting, which can impact sign-in/refresh behavior across the app.
> 
> **Overview**
> Fixes a token refresh edge case in `assets/msalv2.js` where a failed silent refresh could leave the flow unresolved.
> 
> `silentlyAcquireToken()` now assigns and returns `authResult` explicitly, and `refreshToken()` reports an explicit error when silent acquisition returns no token, ensuring callers get either `onSuccess` or `onError` reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a9e09205518dc39d5a6236112cb87eec8c736a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->