### PR TITLE
fix: dont use stale redirect task result

### DIFF
--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -88,20 +88,32 @@ var aadOauth = (function () {
   // Will return the authentication result on success and update the
   // global authResult variable.
   async function silentlyAcquireToken() {
-    try {
-      // The redirect handler task will complete with auth results if we
-      // were redirected from AAD. If not, it will complete with null
-      // We must wait for it to complete before we allow the login to
-      // attempt to acquire a token silently, and then progress to interactive
-      // login (if silent acquisition fails).
-      let result = await redirectHandlerTask;
-      if (result !== null) {
-        authResult = result;
-        return authResult;
+    // Drain the redirect-callback promise exactly once. `redirectHandlerTask`
+    // is a Promise created in `init()` from `handleRedirectPromise()` and
+    // keeps its resolved AuthenticationResult forever. If we re-await it on
+    // every call, every subsequent invocation short-circuits with the
+    // original (and eventually expired) access token, and `acquireTokenSilent`
+    // - which is the only path that uses the cached refresh token to mint a
+    // new access token - is never reached. That breaks silent token renewal
+    // on long-lived tabs and forces interactive re-auth once the access
+    // token expires.
+    if (redirectHandlerTask !== null) {
+      const pendingTask = redirectHandlerTask;
+      redirectHandlerTask = null;
+      try {
+        const result = await pendingTask;
+        if (result !== null) {
+          authResult = result;
+          return authResult;
+        }
       }
-    }
-    catch (error) {
-      authResultError = null;
+      catch (error) {
+        // Swallow and fall through to acquireTokenSilent so we still try to
+        // recover the session from the MSAL cache. We log so the failure
+        // can be diagnosed in the field.
+        console.warn('handleRedirectPromise rejected: ' +
+          (error && error.message ? error.message : error));
+      }
     }
 
     const account = getAccount();
@@ -194,30 +206,17 @@ var aadOauth = (function () {
   // could not be acquired or if no cached account credentials exist.
   // Will call [onSuccess] on success and update the global authResult variable.
   async function refreshToken(onSuccess, onError) {
-    try {
-      // The redirect handler task will complete with auth results if we
-      // were redirected from AAD. If not, it will complete with null
-      // We must wait for it to complete before we allow the login to
-      // attempt to acquire a token silently, and then progress to interactive
-      // login (if silent acquisition fails).
-      let result = await redirectHandlerTask;
-      if (result !== null) {
-        authResult = result;
-      }
-    }
-    catch (error) {
-      authResultError = error;
-      onError(authResultError);
+    // `silentlyAcquireToken` already drains the redirect-callback promise on
+    // first use and otherwise delegates to MSAL's `acquireTokenSilent`, which
+    // refreshes the access token via the cached refresh token when it has
+    // expired. Use its return value rather than the global `authResult` so
+    // that a failed refresh doesn't accidentally surface a stale token left
+    // over from a previous successful acquisition.
+    const result = await silentlyAcquireToken();
+
+    if (result != null && result.accessToken) {
+      onSuccess(result.accessToken);
       return;
-    }
-
-    // Try to sign in silently, assuming we have already signed in and have
-    // a cached access token
-    await silentlyAcquireToken()
-
-    if (authResult != null) {
-      onSuccess(authResult.accessToken ?? null);
-      return
     }
     onError(new Error('Silent token refresh did not produce a token'));
   }

--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -99,7 +99,6 @@ var aadOauth = (function () {
     // token expires.
     if (redirectHandlerTask !== null) {
       const pendingTask = redirectHandlerTask;
-      redirectHandlerTask = null;
       try {
         const result = await pendingTask;
         if (result !== null) {
@@ -113,6 +112,9 @@ var aadOauth = (function () {
         // can be diagnosed in the field.
         console.warn('handleRedirectPromise rejected: ' +
           (error && error.message ? error.message : error));
+      }
+      finally {
+        redirectHandlerTask = null;
       }
     }
 


### PR DESCRIPTION
Fixes an issue that was causing the refresh token flow to fail on browser. 

the init code in msalv2.js has a mechanism built in to prevent a race condition during intitializaiton, whereby any token fetch requests will await the browser redirect callback before resolving. This browser redirect callback contains a valid token that can be used for authentication, however it should not be used for subsequent token refresh calls, as the token eventually will expire and become stale.

In the client, this would manifest as a failure to refresh an auth token if a session is open long enough for it to expire (around 75 minutes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser authentication and token refresh paths; behavior change is targeted but incorrect handling would break long sessions or refresh flows.
> 
> **Overview**
> Fixes **silent token refresh** on long-lived browser tabs by changing how `msalv2.js` handles the MSAL redirect callback promise.
> 
> **`silentlyAcquireToken`** now **awaits `handleRedirectPromise()` only once**, then clears `redirectHandlerTask`. Previously every call re-awaited the same resolved promise and kept returning the **original redirect access token**, so **`acquireTokenSilent` (refresh-token path) never ran** after that token expired (~75 minutes).
> 
> **`refreshToken`** no longer re-waits on the redirect task or succeeds from a stale global `authResult`; it relies on **`silentlyAcquireToken()`’s return value** and only calls `onSuccess` when a fresh `accessToken` is obtained.
> 
> Redirect failures are **logged and ignored** so the flow can still fall through to silent acquisition from the MSAL cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5983049a742a3c1289612fb98c9c669467303285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->